### PR TITLE
fix: Add image_hash support for video thumbnails in video_data

### DIFF
--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -222,6 +222,11 @@ export function registerCreativeTools(
             video_id: video_id,
           };
 
+          // Add thumbnail image hash for video ads (required by Meta API)
+          if (image_hash) {
+            object_story_spec.video_data.image_hash = image_hash;
+          }
+
           if (message) {
             object_story_spec.video_data.message = message;
           }


### PR DESCRIPTION
## Summary
- Adds `image_hash` support to `video_data` for video ad thumbnails

## Problem
When creating video ad creatives, the Meta API requires a thumbnail image (via `image_hash`). Currently, even though `image_hash` is a parameter in the schema, it's only used for `link_data` (image ads) and not for `video_data` (video ads). 

This causes the error: **"Your ad needs a video thumbnail"** (Portuguese: "Seu anúncio precisa de uma miniatura de vídeo").

## Solution
Added the `image_hash` to `video_data` within the `object_story_spec` when creating video ad creatives.

```typescript
// For video creatives
if (video_id) {
  object_story_spec.video_data = {
    video_id: video_id,
  };

  // Add thumbnail image hash for video ads (required by Meta API)
  if (image_hash) {
    object_story_spec.video_data.image_hash = image_hash;
  }
  // ... rest of video_data
}
```

## Testing
- Created video ad creative with thumbnail via the updated MCP server
- Verified proper `object_story_spec.video_data.image_hash` structure in API request

🤖 Generated with [Claude Code](https://claude.com/claude-code)